### PR TITLE
Avoid warning about yaml exploit

### DIFF
--- a/vital/utils/parsing.py
+++ b/vital/utils/parsing.py
@@ -17,6 +17,6 @@ class StoreDictKeyPair(argparse.Action):
         """
         # Hack converting `values` to a YAML document to use the YAML parser's type inference
         yaml_str = values.replace("=", ": ").replace(",", "\n")
-        args_map = yaml.load(yaml_str)
+        args_map = yaml.safe_load(yaml_str)
 
         setattr(namespace, self.dest, args_map)


### PR DESCRIPTION
Voir https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation