### PR TITLE
Save Hydra config choices in hparams 

### DIFF
--- a/vital/runner.py
+++ b/vital/runner.py
@@ -79,7 +79,9 @@ class VitalRunner(ABC):
         datamodule: VitalDataModule = hydra.utils.instantiate(cfg.data)
 
         # Instantiate system (which will handle instantiating the model and optimizer).
-        model: VitalSystem = hydra.utils.instantiate(cfg.task, data_params=datamodule.data_params, _recursive_=False)
+        model: VitalSystem = hydra.utils.instantiate(
+            cfg.task, choices=cfg.choices, data_params=datamodule.data_params, _recursive_=False
+        )
 
         if cfg.ckpt:  # Load pretrained model if checkpoint is provided
             if cfg.weights_only:

--- a/vital/system.py
+++ b/vital/system.py
@@ -22,12 +22,15 @@ class VitalSystem(pl.LightningModule, ABC):
     (e.g. evaluation).
     """
 
-    def __init__(self, model: DictConfig, optim: DictConfig, data_params: DataParameters, **kwargs):
+    def __init__(
+        self, model: DictConfig, optim: DictConfig, choices: DictConfig, data_params: DataParameters, **kwargs
+    ):
         """Saves the system's configuration in `hparams`.
 
         Args:
             model: Nested Omegaconf object containing the model architecture's configuration.
             optim: Nested Omegaconf object containing the optimizers' configuration.
+            choices: Nested Omegaconf object containing the choice made from the pre-set configurations.
             data_params: Parameters related to the data necessary to initialize the model.
             **kwargs: Dictionary of arguments to save as the model's `hparams`.
         """


### PR DESCRIPTION
Save Hydra config choices in hparams to be able to access them when loading models from checkpoints.