### PR TITLE
Improve resolving of repo-related paths

### DIFF
--- a/vital/__init__.py
+++ b/vital/__init__.py
@@ -7,6 +7,15 @@ ENV_VITAL_HOME = "VITAL_HOME"
 DEFAULT_CACHE_DIR = "~/.cache"
 
 
+def get_vital_root() -> Path:
+    """Resolves the root directory for the `vital` library.
+
+    Returns:
+        Path to the root directory for the `vital` library.
+    """
+    return Path(__file__).resolve().parents[1]
+
+
 def get_vital_home() -> Path:
     """Resolves the home directory for the `vital` library, used to save/cache data reusable across scripts/runs.
 

--- a/vital/utils/sys.py
+++ b/vital/utils/sys.py
@@ -4,6 +4,8 @@ import numpy as np
 import torch
 from omegaconf import OmegaConf
 
+from vital import get_vital_root
+
 
 def register_omegaconf_resolvers() -> None:
     """Registers various OmegaConf resolvers useful to query system info."""
@@ -11,3 +13,4 @@ def register_omegaconf_resolvers() -> None:
     OmegaConf.register_new_resolver("sys.num_workers", lambda x=None: os.cpu_count() - 1)
     OmegaConf.register_new_resolver("sys.getcwd", lambda x=None: os.getcwd())
     OmegaConf.register_new_resolver("sys.eps.np", lambda dtype: np.finfo(np.dtype(dtype)).eps)
+    OmegaConf.register_new_resolver("vital.root", lambda x=None: str(get_vital_root()))


### PR DESCRIPTION
- Make sure env variables are loaded before attempting to resolve `vital` home
- Add function + Hydra resolver to get vital root directory