### PR TITLE
Replace `DataTag` by `LabelEnum` and `StrEnum`

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,6 +8,7 @@ scikit-learn
 pandas
 h5py
 PyYAML
+StrEnum
 tqdm
 SimpleITK
 torch~=1.11.0

--- a/vital/data/acdc/config.py
+++ b/vital/data/acdc/config.py
@@ -1,39 +1,37 @@
 from dataclasses import dataclass
+from enum import auto, unique
 from typing import Any, Dict
 
 import numpy as np
+from strenum import LowercaseStrEnum
 
-from vital.data.config import DataTag, Tags
+from vital.data.config import LabelEnum, Tags
 
 
-class Label(DataTag):
-    """Enumeration of tags related to the different anatomical structures segmented in the dataset.
-
-    Attributes:
-        BG: Label of the background.
-        RV: Label of the right ventricle.
-        MYO: Label of the myocardium.
-        LV: Label of the left ventricle.
-    """
+@unique
+class Label(LabelEnum):
+    """Identifiers of the different anatomical structures available in the dataset's segmentation mask."""
 
     BG = 0
+    """BackGround"""
     RV = 1
+    """Right Ventricle"""
     MYO = 2
+    """MYOcardium"""
     LV = 3
+    """Left Ventricle"""
 
 
-class Instant(DataTag):
-    """Collection of tags related to noteworthy 3D volumes of 2D MRI slices.
+@unique
+class Instant(LowercaseStrEnum):
+    """Identifiers of noteworthy 3D volumes of 2D MRI slices."""
 
-    Args:
-        ED: Tag referring to the end-diastolic volume.
-        ES: Tag referring to the end-systolic volume.
-        MID: Tag referring to a sample between ED and ES.
-    """
-
-    ED = "ED"
-    ES = "ES"
-    MID = "MID"
+    ED = auto()
+    """End-Diastolic volume"""
+    ES = auto()
+    """End-Systolic volume"""
+    MID = auto()
+    """Volume in the MIDdle between ED and ES"""
 
 
 @dataclass(frozen=True)

--- a/vital/data/acdc/dataset.py
+++ b/vital/data/acdc/dataset.py
@@ -55,8 +55,7 @@ class Acdc(VisionDataset):
             self.da_transforms = None
 
         super().__init__(path, transform=transform, target_transform=target_transform)
-
-        self.image_set = image_set.value
+        self.image_set = image_set
 
         with h5py.File(path, "r") as f:
             if AcdcTags.registered in f.attrs.keys():
@@ -296,7 +295,7 @@ if __name__ == "__main__":
 
     if params.predict:
         patient = ds[random.randint(0, len(ds) - 1)]
-        instant = patient.instants[Instant.ED.value]
+        instant = patient.instants[Instant.ED]
         img = instant.img
         gt = instant.gt
         print("Image shape: {}".format(img.shape))

--- a/vital/data/acdc/dataset_generator.py
+++ b/vital/data/acdc/dataset_generator.py
@@ -98,7 +98,7 @@ def generate_probability_map(dataset: h5py.File, group: h5py.Group, data_augment
     for label in Label:
         prob_map = np.array(
             [
-                _generate_centered_prob_map(np.copy(img), prior_shape, center, label.value)
+                _generate_centered_prob_map(np.copy(img), prior_shape, center, label)
                 for img, center in tqdm(zip(images, images_center), desc=str(label), total=len(images))
             ]
         )
@@ -237,21 +237,16 @@ def create_database_structure(
         patient = group.create_group(name)
 
         write_instant_group(
-            patient.create_group(Instant.ED.value), ed_img, edg_img, ed_voxel_size, rotation, registering_transformer
+            patient.create_group(Instant.ED), ed_img, edg_img, ed_voxel_size, rotation, registering_transformer
         )
         write_instant_group(
-            patient.create_group(Instant.ES.value), es_img, esg_img, es_voxel_size, rotation, registering_transformer
+            patient.create_group(Instant.ES), es_img, esg_img, es_voxel_size, rotation, registering_transformer
         )
 
         # Add mid-cycle data
         if data_mid:
             write_instant_group(
-                patient.create_group(Instant.MID.value),
-                mid_img,
-                midg_img,
-                mid_voxel_size,
-                rotation,
-                registering_transformer,
+                patient.create_group(Instant.MID), mid_img, midg_img, mid_voxel_size, rotation, registering_transformer
             )
 
 
@@ -324,7 +319,7 @@ def generate_dataset(data_path: Path, output_path: Path, data_augmentation: bool
         output_dataset.attrs[AcdcTags.registered] = registering
 
         # Training samples ###
-        group = output_dataset.create_group(Subset.TRAIN.value)
+        group = output_dataset.create_group(Subset.TRAIN)
         for p_ed, g_ed, p_es, g_es in tqdm(train_paths, desc="Training"):
             # Find missmatch in the zip
             if str(p_ed) != str(g_ed).replace("_gt", "") or str(p_es) != str(g_es).replace("_gt", ""):
@@ -336,7 +331,7 @@ def generate_dataset(data_path: Path, output_path: Path, data_augmentation: bool
         generate_probability_map(output_dataset, group, data_augmentation)
 
         # Validation samples ###
-        group = output_dataset.create_group(Subset.VAL.value)
+        group = output_dataset.create_group(Subset.VAL)
         for p_ed, g_ed, p_es, g_es in tqdm(valid_paths, desc="Validation"):
             # Find missmatch in the zip
             if str(p_ed) != str(g_ed).replace("_gt", "") or str(p_es) != str(g_es).replace("_gt", ""):
@@ -345,7 +340,7 @@ def generate_dataset(data_path: Path, output_path: Path, data_augmentation: bool
             create_database_structure(group, False, registering, p_ed, g_ed, p_es, g_es)
 
         # Testing samples ###
-        group = output_dataset.create_group(Subset.TEST.value)
+        group = output_dataset.create_group(Subset.TEST)
         for p_ed, g_ed, p_mid, g_mid, p_es, g_es in tqdm(test_paths, desc="Testing"):
             p_mid = None if p_mid == "None" else p_mid
             g_mid = None if g_mid == "None" else g_mid

--- a/vital/data/acdc/utils/register.py
+++ b/vital/data/acdc/utils/register.py
@@ -30,7 +30,7 @@ class AcdcRegisteringTransformer(AffineRegisteringTransformer):
             Pixel shift to apply along each axis to center the segmentation around the LV/MYO mass.
         """
         segmentation_center = np.array(segmentation.shape[:2]) // 2
-        lv_myo_center = np.array(self._find_structure_center(segmentation, [Label.LV.value, Label.MYO.value]))
+        lv_myo_center = np.array(self._find_structure_center(segmentation, [Label.LV, Label.MYO]))
         return (lv_myo_center - segmentation_center).astype(int)
 
     def _compute_rotation_parameters(self, segmentation: np.ndarray) -> Rotation:
@@ -46,10 +46,8 @@ class AcdcRegisteringTransformer(AffineRegisteringTransformer):
             Angle of the rotation to apply to align the segmentation so that the RV center of mass is always
             left of the LV/MYO center of mass on a straight horizontal line.
         """
-        lv_myo_center = np.array(self._find_structure_center(segmentation, [Label.LV.value, Label.MYO.value]))
-        rv_center = np.array(
-            self._find_structure_center(segmentation, Label.RV.value, default_center=tuple(lv_myo_center))
-        )
+        lv_myo_center = np.array(self._find_structure_center(segmentation, [Label.LV, Label.MYO]))
+        rv_center = np.array(self._find_structure_center(segmentation, Label.RV, default_center=tuple(lv_myo_center)))
         centers_diff = rv_center - lv_myo_center
         rotation_angle = degrees(np.arctan2(centers_diff[1], centers_diff[0]))
         rotation_angle = -(180 - ((rotation_angle + 360) % 360))

--- a/vital/data/camus/config.py
+++ b/vital/data/camus/config.py
@@ -1,25 +1,24 @@
 from dataclasses import dataclass
+from enum import unique
 from typing import Any, Dict, List, Literal, Sequence
 
 import numpy as np
 
-from vital.data.config import DataTag, Tags
+from vital.data.config import LabelEnum, Tags
 
 
-class Label(DataTag):
-    """Enumeration of tags related to the different anatomical structures segmented in the dataset.
-
-    Attributes:
-        BG: Label of the background.
-        LV: Label of the left ventricle, bounded by the endocardium.
-        MYO: Label of the myocardium, bounded by the encocardium and epicardium.
-        ATRIUM: Label of the left atrium.
-    """
+@unique
+class Label(LabelEnum):
+    """Identifiers of the different anatomical structures available in the dataset's segmentation mask."""
 
     BG = 0
+    """BackGround"""
     LV = 1
+    """Left Ventricle"""
     MYO = 2
+    """MYOcardium"""
     ATRIUM = 3
+    """Atrium"""
 
 
 @dataclass(frozen=True)

--- a/vital/data/camus/data_module.py
+++ b/vital/data/camus/data_module.py
@@ -7,7 +7,7 @@ from torch.utils.data import DataLoader
 
 from vital.data.camus.config import CamusTags, Label, in_channels
 from vital.data.camus.dataset import Camus
-from vital.data.config import DataParameters, Subset
+from vital.data.config import DataParameters, ProtoLabel, Subset
 from vital.data.data_module import VitalDataModule
 from vital.data.mixins import StructuredDataMixin
 
@@ -18,7 +18,7 @@ class CamusDataModule(StructuredDataMixin, VitalDataModule):
     def __init__(
         self,
         dataset_path: Union[str, Path],
-        labels: Sequence[Union[str, Label]] = Label,
+        labels: Sequence[ProtoLabel] = Label,
         fold: int = 5,
         use_sequence: bool = False,
         num_neighbors: int = 0,
@@ -40,7 +40,7 @@ class CamusDataModule(StructuredDataMixin, VitalDataModule):
             **kwargs: Keyword arguments to pass to the parent's constructor.
         """
         dataset_path = Path(dataset_path)
-        labels = tuple(Label.from_name(str(label)) for label in labels)
+        labels = tuple(Label.from_proto_labels(labels))
 
         # Infer the shape of the data from the content of the dataset.
         try:
@@ -132,7 +132,7 @@ class CamusDataModule(StructuredDataMixin, VitalDataModule):
         # Add arguments w/ custom types not supported by Lightning's argparse creation tool
         dm_arg_group.add_argument(
             "--labels",
-            type=Label.from_name,
+            type=Label.from_proto_label,
             default=tuple(Label),
             nargs="+",
             choices=tuple(Label),

--- a/vital/data/camus/dataset.py
+++ b/vital/data/camus/dataset.py
@@ -128,7 +128,7 @@ class Camus(VisionDataset):
             # List the patients
             groups = [
                 patient_path_byte.decode()
-                for patient_path_byte in dataset[f"cross_validation/fold_{self.fold}/{self.image_set.value}"]
+                for patient_path_byte in dataset[f"cross_validation/fold_{self.fold}/{self.image_set}"]
             ]
             if level == "view":
                 groups = [f"{patient}/{view}" for patient in groups for view in dataset[patient].keys()]
@@ -325,10 +325,7 @@ class Camus(VisionDataset):
             Target data arrays processed and formatted.
         """
         return [
-            remove_labels(
-                target_data, [lbl.value for lbl in self.labels_to_remove], fill_label=Label.BG.value
-            ).squeeze()
-            for target_data in args
+            remove_labels(target_data, self.labels_to_remove, fill_label=Label.BG).squeeze() for target_data in args
         ]
 
     @staticmethod
@@ -380,27 +377,23 @@ def get_segmentation_attributes(
     if Label.LV in labels:
         attrs.update(
             {
-                CamusTags.lv_area: EchoMeasure.structure_area(segmentation, Label.LV.value),
+                CamusTags.lv_area: EchoMeasure.structure_area(segmentation, Label.LV),
                 CamusTags.lv_orientation: EchoMeasure.structure_orientation(
-                    segmentation, Label.LV.value, reference_orientation=90
+                    segmentation, Label.LV, reference_orientation=90
                 ),
             }
         )
     if Label.MYO in labels:
-        attrs.update({CamusTags.myo_area: EchoMeasure.structure_area(segmentation, Label.MYO.value)})
+        attrs.update({CamusTags.myo_area: EchoMeasure.structure_area(segmentation, Label.MYO)})
     if Label.LV in labels and Label.MYO in labels:
         attrs.update(
             {
-                CamusTags.lv_base_width: EchoMeasure.lv_base_width(segmentation, Label.LV.value, Label.MYO.value),
-                CamusTags.lv_length: EchoMeasure.lv_length(segmentation, Label.LV.value, Label.MYO.value),
-                CamusTags.epi_center_x: EchoMeasure.structure_center(
-                    segmentation, [Label.LV.value, Label.MYO.value], axis=1
-                ),
-                CamusTags.epi_center_y: EchoMeasure.structure_center(
-                    segmentation, [Label.LV.value, Label.MYO.value], axis=0
-                ),
+                CamusTags.lv_base_width: EchoMeasure.lv_base_width(segmentation, Label.LV, Label.MYO),
+                CamusTags.lv_length: EchoMeasure.lv_length(segmentation, Label.LV, Label.MYO),
+                CamusTags.epi_center_x: EchoMeasure.structure_center(segmentation, [Label.LV, Label.MYO], axis=1),
+                CamusTags.epi_center_y: EchoMeasure.structure_center(segmentation, [Label.LV, Label.MYO], axis=0),
             }
         )
     if Label.ATRIUM in labels:
-        attrs.update({CamusTags.atrium_area: EchoMeasure.structure_area(segmentation, Label.ATRIUM.value)})
+        attrs.update({CamusTags.atrium_area: EchoMeasure.structure_area(segmentation, Label.ATRIUM)})
     return attrs

--- a/vital/data/camus/dataset_generator.py
+++ b/vital/data/camus/dataset_generator.py
@@ -101,7 +101,7 @@ class CrossValidationDatasetGenerator:
                 fold_group = cross_validation_group.create_group(f"fold_{fold}")
                 for subset, subset_name_in_data in self._subset_names_in_data.items():
                     fold_subset_patients = self.get_fold_subset_from_file(data, fold, subset_name_in_data)
-                    fold_group.create_dataset(subset.value, data=np.array(fold_subset_patients, dtype="S"))
+                    fold_group.create_dataset(subset, data=np.array(fold_subset_patients, dtype="S"))
 
             # Get a list of all the patients in the dataset
             patient_ids = reduce(
@@ -151,7 +151,7 @@ class CrossValidationDatasetGenerator:
             # The order of the instants within a view dataset is chronological: ED -> ES -> ED
             data_x, data_y, view_metadata, instants = self._get_view_data(patient_id, view)
 
-            data_y = remove_labels(data_y, [lbl.value for lbl in self.labels_to_remove], fill_label=Label.BG.value)
+            data_y = remove_labels(data_y, self.labels_to_remove, fill_label=Label.BG)
 
             if self.flags[CamusTags.registered]:
                 registering_parameters, data_y_proc, data_x_proc = self.registering_transformer.register_batch(
@@ -313,7 +313,7 @@ def main():
     parser.add_argument("-r", "--register", action="store_true", help="Apply registering on images and groundtruths")
     parser.add_argument(
         "--labels",
-        type=Label.from_name,
+        type=Label.from_proto_label,
         default=list(Label),
         nargs="+",
         choices=list(Label),

--- a/vital/data/camus/utils/register.py
+++ b/vital/data/camus/utils/register.py
@@ -31,13 +31,13 @@ class CamusRegisteringTransformer(AffineRegisteringTransformer):
         """
         # Find the bottom limit of the atrium
         # (using a bounding box encompassing all segmentation classes)
-        segmentation_mask = 1 - segmentation[..., Label.BG.value]
+        segmentation_mask = 1 - segmentation[..., Label.BG]
         segmentation_props = regionprops(segmentation_mask)[0]
         distance_from_left_atrium_to_border = segmentation.shape[0] - segmentation_props.bbox[2]
 
         # Find the center of mass of the epicardium (union of the left ventricle and myocardium)
         segmentation_center = segmentation.shape[0] // 2, segmentation.shape[1] // 2
-        epicardium_center = Measure.structure_center(to_categorical(segmentation), [Label.LV.value, Label.MYO.value])
+        epicardium_center = Measure.structure_center(to_categorical(segmentation), [Label.LV, Label.MYO])
 
         # Center the image as closely as possible around the epicardium without cutting off the left atrium
         rows_shift = max(epicardium_center[0] - segmentation_center[0], -distance_from_left_atrium_to_border)
@@ -53,9 +53,7 @@ class CamusRegisteringTransformer(AffineRegisteringTransformer):
         Returns:
             Angle of the rotation to align the major axis of the left ventricle with the vertical axis.
         """
-        return Measure.structure_orientation(
-            to_categorical(segmentation), Label.LV.value, reference_orientation=90
-        ).item()
+        return Measure.structure_orientation(to_categorical(segmentation), Label.LV, reference_orientation=90).item()
 
     def _compute_crop_parameters(self, segmentation: np.ndarray, margin: float = 0.05) -> Crop:
         """Computes the coordinates of an isotropic bounding box around all segmented classes.
@@ -99,9 +97,9 @@ class CamusRegisteringTransformer(AffineRegisteringTransformer):
     #     """
     #     # Find dimensions of the bounding box encompassing all segmentation classes
     #     segmentation_mask = (
-    #         segmentation[..., Label.LV.value]
-    #         | segmentation[..., Label.MYO.value]
-    #         | segmentation[..., Label.ATRIUM.value]
+    #         segmentation[..., Label.LV]
+    #         | segmentation[..., Label.MYO]
+    #         | segmentation[..., Label.ATRIUM]
     #     )
     #     segmentation_props = regionprops(segmentation_mask)[0]
     #     segmentation_bbox = segmentation_props.bbox

--- a/vital/metrics/camus/anatomical/atrium_metrics.py
+++ b/vital/metrics/camus/anatomical/atrium_metrics.py
@@ -13,4 +13,4 @@ class LeftAtriumMetrics(Anatomical2DStructureMetrics):
             segmentation_metrics: Instance, based on the segmentation for which to compute anatomical metrics, of the
                 class implementing various segmentation metrics.
         """
-        super().__init__(segmentation_metrics, Label.ATRIUM.value)
+        super().__init__(segmentation_metrics, Label.ATRIUM)

--- a/vital/metrics/camus/anatomical/epi_metrics.py
+++ b/vital/metrics/camus/anatomical/epi_metrics.py
@@ -15,4 +15,4 @@ class EpicardiumMetrics(Anatomical2DStructureMetrics):
         """
         # For myocardium we want to calculate anatomical metrics for the entire epicardium
         # Therefore we concatenate label 1 (lumen) and 2 (myocardium)
-        super().__init__(segmentation_metrics, (Label.LV.value, Label.MYO.value))
+        super().__init__(segmentation_metrics, (Label.LV, Label.MYO))

--- a/vital/metrics/camus/anatomical/frontier_metrics.py
+++ b/vital/metrics/camus/anatomical/frontier_metrics.py
@@ -20,7 +20,7 @@ class FrontierMetrics:
         Returns:
             Count of pixels in the gap between the two areas segmented as left ventricle and myocardium.
         """
-        return self.segmentation_metrics.count_holes_between_regions(Label.LV.value, Label.MYO.value)
+        return self.segmentation_metrics.count_holes_between_regions(Label.LV, Label.MYO)
 
     def count_holes_between_lv_and_atrium(self) -> int:
         """Counts the pixels in the gap between the left ventricle (LV) and left atrium.
@@ -28,7 +28,7 @@ class FrontierMetrics:
         Returns:
             Count of pixels in the gap between the two areas segmented as left ventricle and left atrium.
         """
-        return self.segmentation_metrics.count_holes_between_regions(Label.LV.value, Label.MYO.value)
+        return self.segmentation_metrics.count_holes_between_regions(Label.LV, Label.MYO)
 
     def measure_frontier_ratio_between_lv_and_bg(self) -> float:
         """Measures the ratio between the length of the frontier between the LV and BG and the width of the LV.
@@ -36,7 +36,7 @@ class FrontierMetrics:
         Returns:
             Ratio between the length of the frontier between the LV and BG and the width of the LV.
         """
-        return self.segmentation_metrics.measure_frontier_ratio_between_regions(Label.LV.value, Label.BG.value)
+        return self.segmentation_metrics.measure_frontier_ratio_between_regions(Label.LV, Label.BG)
 
     def measure_frontier_ratio_between_myo_and_atrium(self) -> float:
         """Measures the ratio between the length of the frontier between the MYO and atrium and the width of the MYO.
@@ -44,4 +44,4 @@ class FrontierMetrics:
         Returns:
             Ratio between the length of the frontier between the MYO and atrium and the width of the MYO.
         """
-        return self.segmentation_metrics.measure_frontier_ratio_between_regions(Label.MYO.value, Label.ATRIUM.value)
+        return self.segmentation_metrics.measure_frontier_ratio_between_regions(Label.MYO, Label.ATRIUM)

--- a/vital/metrics/camus/anatomical/lv_metrics.py
+++ b/vital/metrics/camus/anatomical/lv_metrics.py
@@ -13,4 +13,4 @@ class LeftVentricleMetrics(Anatomical2DStructureMetrics):
             segmentation_metrics: Instance, based on the segmentation for which to compute anatomical metrics, of the
                 class implementing various segmentation metrics.
         """
-        super().__init__(segmentation_metrics, Label.LV.value)
+        super().__init__(segmentation_metrics, Label.LV)

--- a/vital/metrics/camus/anatomical/myo_metrics.py
+++ b/vital/metrics/camus/anatomical/myo_metrics.py
@@ -13,4 +13,4 @@ class MyocardiumMetrics(Anatomical2DStructureMetrics):
             segmentation_metrics: Instance, based on the segmentation for which to compute anatomical metrics, of the
                 class implementing various segmentation metrics.
         """
-        super().__init__(segmentation_metrics, Label.MYO.value)
+        super().__init__(segmentation_metrics, Label.MYO)

--- a/vital/metrics/camus/anatomical/size_metrics.py
+++ b/vital/metrics/camus/anatomical/size_metrics.py
@@ -26,5 +26,5 @@ class SizeMetrics:
             an horizontal line anchored at their joined center of mass.
         """
         return self.segmentation_metrics.measure_width_ratio_between_regions(
-            Label.LV.value, Label.MYO.value, no_structure_flag=self.no_structure_flag
+            Label.LV, Label.MYO, no_structure_flag=self.no_structure_flag
         )

--- a/vital/metrics/camus/anatomical/utils.py
+++ b/vital/metrics/camus/anatomical/utils.py
@@ -54,7 +54,7 @@ def compute_anatomical_metrics_by_segmentation(
     # Therefore we concatenate label 1 (lumen) and 2 (myocardium)
     segmentation_metrics = Segmentation2DMetrics(
         segmentation,
-        [Label.BG.value, Label.LV.value, Label.MYO.value, (Label.LV.value, Label.MYO.value), Label.ATRIUM.value],
+        [Label.BG, Label.LV, Label.MYO, (Label.LV, Label.MYO), Label.ATRIUM],
         voxelspacing=voxelspacing,
     )
     lv_metrics = LeftVentricleMetrics(segmentation_metrics)

--- a/vital/metrics/camus/clinical/utils.py
+++ b/vital/metrics/camus/clinical/utils.py
@@ -27,8 +27,8 @@ def compute_clinical_metrics_by_patient(
         Mapping between the clinical metrics' names and their value for the patient.
     """
     # Extract left ventricle masks from the data
-    results_masks = [np.isin(result, Label.LV.value) for result in results]
-    references_masks = [np.isin(reference, Label.LV.value) for reference in references]
+    results_masks = [np.isin(result, Label.LV) for result in results]
+    references_masks = [np.isin(reference, Label.LV) for reference in references]
 
     # Compute clinical metrics on groundtruth
     gt_lv_edv, gt_lv_esv = compute_left_ventricle_volumes(

--- a/vital/results/camus/__init__.py
+++ b/vital/results/camus/__init__.py
@@ -19,10 +19,10 @@ class CamusResultsProcessor(ABC):
         """
         parser.add_argument(
             "--labels",
-            type=Label.from_name,
-            default=list(Label),
+            type=Label.from_proto_label,
+            default=tuple(Label),
             nargs="+",
-            choices=list(Label),
+            choices=tuple(Label),
             help="Labels of the classes included in the segmentations. By default, considers that all class labels "
             "provided in the dataset are included",
         )

--- a/vital/results/camus/anatomical_metrics.py
+++ b/vital/results/camus/anatomical_metrics.py
@@ -1,9 +1,10 @@
 from argparse import ArgumentParser
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Tuple
 
 import numpy as np
 
 from vital.data.camus.config import CamusTags, Label
+from vital.data.config import ProtoLabel
 from vital.metrics.camus.anatomical import config
 from vital.metrics.camus.anatomical.utils import compute_anatomical_metrics_by_segmentation
 from vital.results import anatomical_metrics
@@ -24,7 +25,7 @@ class AnatomicalMetrics(anatomical_metrics.AnatomicalMetrics):
     ]
     thresholds = config.thresholds
 
-    def __init__(self, labels: Sequence[Union[str, Label]], shape: Tuple[int, int] = None, **kwargs):
+    def __init__(self, labels: Sequence[ProtoLabel], shape: Tuple[int, int] = None, **kwargs):
         """Initializes class instance.
 
         Args:
@@ -37,7 +38,7 @@ class AnatomicalMetrics(anatomical_metrics.AnatomicalMetrics):
         self.shape = shape
 
         # Make sure labels are defined using the enum
-        self.labels = tuple(Label.from_name(str(label)) for label in labels)
+        self.labels = Label.from_proto_labels(labels)
 
     def process_result(self, result: InstantResult) -> Tuple[str, "AnatomicalMetrics.ProcessingOutput"]:
         """Computes anatomical metrics on data from an instant.

--- a/vital/results/camus/clinical_metrics.py
+++ b/vital/results/camus/clinical_metrics.py
@@ -80,7 +80,7 @@ class ClinicalMetrics(Metrics):
 
             def _compute_lv_area(data_tag: str) -> Tuple[int, int]:
                 ed, es = data[data_tag].data
-                return np.isin(ed, Label.LV.value).sum(), np.isin(es, Label.LV.value).sum()
+                return np.isin(ed, Label.LV).sum(), np.isin(es, Label.LV).sum()
 
             gt_lv_ed_area, gt_lv_es_area = _compute_lv_area(self.target_tag)
             lv_ed_area, lv_es_area = _compute_lv_area(self.input_tag)


### PR DESCRIPTION
While `LabelEnum` is more complex than the previous `DataTag`, it is simpler on the user front, since it can be used seamlessly as an int. The priority here is to reduce the user-side complexity of using the enums.