### PR TITLE
Migrate from `gpus` flag (to be deprecated in PL 1.7) to `accelerator` and `devices`

### DIFF
--- a/vital/config/trainer/default.yaml
+++ b/vital/config/trainer/default.yaml
@@ -1,3 +1,4 @@
 _target_: pytorch_lightning.Trainer
-gpus: ${sys.gpus:}
+accelerator: "auto"
+devices: null
 enable_progress_bar: True

--- a/vital/utils/sys.py
+++ b/vital/utils/sys.py
@@ -1,7 +1,6 @@
 import os
 
 import numpy as np
-import torch
 from omegaconf import OmegaConf
 
 from vital import get_vital_root
@@ -9,7 +8,6 @@ from vital import get_vital_root
 
 def register_omegaconf_resolvers() -> None:
     """Registers various OmegaConf resolvers useful to query system info."""
-    OmegaConf.register_new_resolver("sys.gpus", lambda x=None: int(torch.cuda.is_available()))
     OmegaConf.register_new_resolver("sys.num_workers", lambda x=None: os.cpu_count() - 1)
     OmegaConf.register_new_resolver("sys.getcwd", lambda x=None: os.getcwd())
     OmegaConf.register_new_resolver("sys.eps.np", lambda dtype: np.finfo(np.dtype(dtype)).eps)


### PR DESCRIPTION
Link to the [PR that deprecated these flags](https://github.com/Lightning-AI/lightning/pull/11040), which got released in [Lightning 1.7.0](https://github.com/Lightning-AI/lightning/releases/tag/1.7.0).

@lemairecarl and @ThierryJudge I'm tagging you as reviewer not because I expect a lot of feedback, but more as a warning about the change, since it's one of the few `Trainer` flags that I think you might use on your end.