### PR TITLE
Fix `flake8` hook repo URL + update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,15 +19,15 @@ repos:
         types: [python]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.8.0
     hooks:
       - id: black
         name: black
         args: [--config, ./pyproject.toml]
         types: [python]
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         name: flake8
@@ -36,7 +36,7 @@ repos:
         types: [python]
 
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.5.0
+    rev: 0.6.0
     hooks:
       - id: nbstripout
         files: '.ipynb'

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 pre-commit~=2.17.0
 isort~=5.10.1
-black~=22.3.0
-flake8~=3.9.2
+black~=22.8.0
+flake8~=5.0.4
 flake8-docstrings~=1.6.0


### PR DESCRIPTION
Fixes issues (e.g. support for newer language feature) caused by the very outdated `flake8` hook (which was not updated because the Gitlab version has not been updated after 3.X series)