### PR TITLE
Simplify shapes returned by functions using `@batch_function` decorator

### DIFF
--- a/vital/data/camus/dataset.py
+++ b/vital/data/camus/dataset.py
@@ -371,7 +371,7 @@ def get_segmentation_attributes(
         labels: Labels of the classes included in the segmentation(s).
 
     Returns:
-        Mapping between the attributes and ([N], 1) arrays of their values for each segmentation in the batch.
+        Mapping between the attributes and arrays of shape ([N]) of their values for each segmentation in the batch.
     """
     attrs = {}
     if Label.LV in labels:

--- a/vital/data/camus/predict.py
+++ b/vital/data/camus/predict.py
@@ -190,7 +190,7 @@ class CamusPredictionWriter(BasePredictionWriter):
                 ds = data_group.create_dataset(CamusTags.raw, data=data, **seg_save_options)
                 # Save shape attributes of the segmentation as dataset attributes
                 for attr, attr_val in get_segmentation_attributes(data, pl_module.hparams.data_params.labels).items():
-                    ds.attrs[attr] = attr_val.squeeze()
+                    ds.attrs[attr] = attr_val
 
             # Save auxiliary predictions
             pred_group = view_group[CamusTags.pred]
@@ -252,7 +252,7 @@ class CamusPredictionWriter(BasePredictionWriter):
                 post_ds = view_pred_group.require_dataset(CamusTags.post, shape=post.shape, **seg_save_options)
                 post_ds[...] = post
                 for attr, attr_val in get_segmentation_attributes(post, pl_module.hparams.data_params.labels).items():
-                    post_ds.attrs[attr] = attr_val.squeeze()
+                    post_ds.attrs[attr] = attr_val
 
                 if enc is not None:
                     enc_ds = view_pred_group.require_dataset(CamusTags.encoding, shape=enc.shape, **img_save_options)

--- a/vital/tasks/autoencoder.py
+++ b/vital/tasks/autoencoder.py
@@ -321,15 +321,15 @@ class SegmentationArVaeTask(SegmentationBetaVaeTask):
 
         for attr_idx, attr in enumerate(self.hparams.attrs):
             # Extract dimension to regularize and target for the current attribute
-            latent_code = out[self.model.encoding_tag][:, attr_idx].unsqueeze(1)
+            latent_code = out[self.model.encoding_tag][:, attr_idx]
             attribute = batch[attr]
 
             # Compute latent distance matrix
-            latent_code = latent_code.repeat(1, latent_code.shape[0])
+            latent_code = latent_code.view(-1, 1).repeat(1, len(latent_code))
             lc_dist_mat = latent_code - latent_code.transpose(1, 0)
 
             # Compute attribute distance matrix
-            attribute = attribute.repeat(1, attribute.shape[0])
+            attribute = attribute.view(-1, 1).repeat(1, len(attribute))
             attribute_dist_mat = attribute - attribute.transpose(1, 0)
 
             # Compute regularization loss

--- a/vital/utils/decorators.py
+++ b/vital/utils/decorators.py
@@ -84,8 +84,6 @@ def batch_function(item_ndim: int) -> Callable:
                 )
             if data.ndim == item_ndim:  # If the input data is a single item
                 result = np.array(func(*self_or_empty, data, *args, **kwargs))
-                if result.ndim == 0:  # If the function's output is a single number, add a dim of 1 for consistency
-                    result = result[None]
             elif data.ndim == (item_ndim + 1):  # If the input data is a batch of items
                 result = np.array([func(*self_or_empty, item, *args, **kwargs) for item in data])
             else:

--- a/vital/utils/image/measure.py
+++ b/vital/utils/image/measure.py
@@ -47,7 +47,7 @@ class Measure:
             ([N], [2]), Center of mass of the structure, for a specified axis or across all axes, in each segmentation
             of the batch.
         """
-        center = ndimage.measurements.center_of_mass(np.isin(segmentation, labels))
+        center = ndimage.center_of_mass(np.isin(segmentation, labels))
         if any(np.isnan(center)):  # Default to the center of the image if the center of mass can't be found
             center = np.array(segmentation.shape) // 2
         if axis is not None:

--- a/vital/utils/image/measure.py
+++ b/vital/utils/image/measure.py
@@ -26,9 +26,9 @@ class Measure:
             labels: Labels of the classes that are part of the structure for which to count the number of pixels.
 
         Returns:
-            ([N], 1), Number of pixels associated to the structure, in each segmentation of the batch.
+            ([N]), Number of pixels associated to the structure, in each segmentation of the batch.
         """
-        return np.isin(segmentation, labels).sum((-2, -1))[..., None]
+        return np.isin(segmentation, labels).sum((-2, -1))
 
     @staticmethod
     @auto_cast_data
@@ -39,12 +39,12 @@ class Measure:
         Args:
             segmentation: ([N], H, W), Segmentation in which to identify the center of mass of the structure.
             labels: Labels of the classes that are part of the structure for which to measure the center of mass.
-            axis: Index of a dimension of interest for which to get the center of mass. If provided, the value of the
+            axis: Index of a dimension of interest, for which to get the center of mass. If provided, the value of the
                 center of mass will only be returned for this axis. If `None`, the center of mass along all axes will be
                 returned.
 
         Returns:
-            ([N], {1|2}), Center of mass of the structure, for a specified axis or across all axes, in each segmentation
+            ([N], [2]), Center of mass of the structure, for a specified axis or across all axes, in each segmentation
             of the batch.
         """
         center = ndimage.measurements.center_of_mass(np.isin(segmentation, labels))
@@ -68,7 +68,7 @@ class Measure:
                 axis.
 
         Returns:
-            ([N], 1), Orientation of the structure w.r.t. the reference orientation, in each segmentation of the batch.
+            ([N]), Orientation of the structure w.r.t. the reference orientation, in each segmentation of the batch.
         """
         structure_mask = np.isin(segmentation, labels)
         if np.any(structure_mask):  # If the structure is present in the segmentation

--- a/vital/utils/image/us/measure.py
+++ b/vital/utils/image/us/measure.py
@@ -82,7 +82,7 @@ class EchoMeasure(Measure):
                 necessary to identify the markers at the base of the left ventricle.
 
         Returns:
-            ([N], 1), Distance between the left and right markers at the base of the left ventricle, or NaNs for the
+            ([N]), Distance between the left and right markers at the base of the left ventricle, or NaNs for the
             images where those 2 points cannot be reliably estimated.
         """
         lv_base_coords = EchoMeasure._lv_base(segmentation, lv_labels=lv_labels, myo_labels=myo_labels)
@@ -105,7 +105,7 @@ class EchoMeasure(Measure):
                 necessary to identify the markers at the base of the left ventricle.
 
         Returns:
-            ([N], 1), Length of the left ventricle, or NaNs for the images where the LV base's midpoint cannot be
+            ([N]), Length of the left ventricle, or NaNs for the images where the LV base's midpoint cannot be
             reliably estimated.
         """
         # Identify the base of the left ventricle


### PR DESCRIPTION
- Batched function over a single item no longer adds a dim of size 1 for single-value returns
- Adapted `Measure` vectorized methods to return arrays with the same shapes as batched functions
- Dowstream code that used the outputs of batched functions was adapted to fit the new standard

Unrelated deprecation fix:
- Update the package `center_of_mass` is imported from in `scipy`