### PR TITLE
Refactor `DataParameters` from `dataclass` to `NamedTuple` + add support for dict data shapes

### DIFF
--- a/vital/data/config.py
+++ b/vital/data/config.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import IntEnum, auto, unique
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from strenum import LowercaseStrEnum
 
@@ -90,16 +90,20 @@ class Tags:
     encoding: str = "z"
 
 
-@dataclass(frozen=True)
-class DataParameters:
+_Size = Tuple[int, ...]
+
+
+class DataParameters(NamedTuple):
     """Class for defining parameters related to the nature of the data.
 
     Args:
-        in_shape: Shape of the input data, if constant for all items (e.g. channels, height, width).
-        out_shape: Shape of the target data, if constant for all items (e.g. classes, height, width).
+        in_shape: Shape of the input data, if constant for all items (e.g. channels, height, width). It can be a dict of
+            multiple shapes in the case of multi-modal data.
+        out_shape: Shape of the target data, if constant for all items (e.g. classes, height, width). It can be a dict
+            of multiple shapes in the case of multi-modal data.
         labels: Labels provided with the data, required when using segmentation task APIs.
     """
 
-    in_shape: Optional[Tuple[int, ...]] = None
-    out_shape: Optional[Tuple[int, ...]] = None
+    in_shape: Optional[Union[_Size, Dict[str, _Size]]] = None
+    out_shape: Optional[Union[_Size, Dict[str, _Size]]] = None
     labels: Optional[Tuple[LabelEnum, ...]] = None

--- a/vital/system.py
+++ b/vital/system.py
@@ -41,8 +41,19 @@ class VitalSystem(pl.LightningModule, ABC):
         # Also save the classpath of the system to be able to load a checkpoint w/o knowing it's type beforehand
         self.save_hyperparameters({"task": {"_target_": f"{self.__class__.__module__}.{self.__class__.__name__}"}})
 
-        # By default, assumes the provided data shape is in channel-first format
-        self.example_input_array = torch.randn((2, *self.hparams.data_params.in_shape))
+    @property
+    def example_input_array(self) -> torch.Tensor:
+        """Tensor of random data, passed to `forward` during setup to determine the model's architecture."""
+        in_shape = self.hparams.data_params.in_shape
+        if isinstance(in_shape, tuple):
+            # By default, assumes the provided data shape is in the same format (e.g. channel-first) as the tensors
+            return torch.randn((2, *self.hparams.data_params.in_shape))
+        else:
+            raise NotImplementedError(
+                "A default implementation of `example_input_array` is only provided for tuple input data shapes, since "
+                "it is the only case when a sensible default can be determined, but the input data shape of the "
+                f"provided dataset is of type: '{type(in_shape)}'."
+            )
 
     def configure_model(self) -> nn.Module:
         """Configure the network architecture used by the system."""

--- a/vital/tasks/autoencoder.py
+++ b/vital/tasks/autoencoder.py
@@ -40,7 +40,6 @@ class SegmentationAutoencoderTask(SharedStepsTask):
         """
         super().__init__(*args, **kwargs)
         self.model = self.configure_model()
-        self.example_input_array = torch.randn((2, *self.hparams.data_params.out_shape))
 
         # Configure metric objects used repeatedly in the train/eval loop
         self._dice = DifferentiableDiceCoefficient(include_background=False, reduction="none")
@@ -57,6 +56,11 @@ class SegmentationAutoencoderTask(SharedStepsTask):
         }
         for stat, init_tensor in self._init_latent_stats.items():
             self.register_buffer(stat, init_tensor)
+
+    @property
+    def example_input_array(self) -> Tensor:
+        """Redefine example input array since segmentation autoencoders are based on the datasets' output shapes."""
+        return torch.randn((2, *self.hparams.data_params.out_shape))
 
     def configure_model(self) -> nn.Module:  # noqa: D102
         return hydra.utils.instantiate(


### PR DESCRIPTION
Following support of dict data shapes, also refactor `example_input_array` in `VitalSystem` as property to facilitate override of default implementation.