### PR TITLE
Better document load_from_checkpoint

### DIFF
--- a/vital/utils/saving.py
+++ b/vital/utils/saving.py
@@ -118,7 +118,7 @@ def load_from_checkpoint(
             check, and raise an error if the expected system type does not match the loaded system.
 
     Returns:
-        Lightning module (specifically a subclass of VitalSystem) loaded from the checkpoint, casted to its original
+        Lightning module (specifically a subclass of VitalSystem) loaded from the checkpoint, cast to its original
         type.
     """
     # Resolve the local path of the checkpoint


### PR DESCRIPTION
I consider this a WIP, your comments/suggestions/commits are welcome!

* I think using "model" in this context is confusing. In `vital`, a "system" is a LightningModule, and a "model" is a nn.Module. But I guess it's fine to call a checkpoint a (saved) model, so that's why I left "model" in the exception message. That's totally arbitrary. :)
* I tried to dissipate some confusion about the type of objects we are dealing with. This version seems better to me, but you might not agree. Suggestions are welcome.