### PR TITLE
Update dependencies to support PyTorch 2-series + fix breaking changes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "~3.10.6"
-torch = "~1.12.0"
-torchvision = "~0.13.0"
-pytorch-lightning = "~1.8.0"
-hydra-core = "~1.2.0"
+torch = "~2.0.0"
+torchvision = "~0.15.1"
+pytorch-lightning = { version = "~2.0.0", extras = ["extra"] }
+hydra-core = "~1.3.0"
 torchmetrics = "*"
 torchinfo = "*"
 pathos = "*"

--- a/vital/config/trainer/default.yaml
+++ b/vital/config/trainer/default.yaml
@@ -1,5 +1,5 @@
 _target_: pytorch_lightning.Trainer
 accelerator: "auto"
-devices: null
+devices: "auto"
 enable_progress_bar: True
 enable_model_summary: True

--- a/vital/config/vital_default.yaml
+++ b/vital/config/vital_default.yaml
@@ -19,7 +19,6 @@ ckpt: null
 weights_only: False
 strict: True
 
-tune: False
 train: True
 test: False
 predict: True

--- a/vital/data/camus/data_module.py
+++ b/vital/data/camus/data_module.py
@@ -96,7 +96,7 @@ class CamusDataModule(StructuredDataMixin, VitalDataModule):
     @classmethod
     def add_argparse_args(cls, parent_parser: ArgumentParser, **kwargs) -> ArgumentParser:
         """Override of generic ``add_argparse_args`` to manually add parser for arguments of custom types."""
-        parser = super().add_argparse_args(parent_parser)
+        parser = super().add_argparse_args(parent_parser, **kwargs)
 
         # Hack to fetch the argument group created specifically for the data module's arguments
         dm_arg_group = [

--- a/vital/data/data_module.py
+++ b/vital/data/data_module.py
@@ -4,7 +4,6 @@ from argparse import ArgumentParser
 from typing import Dict
 
 import pytorch_lightning as pl
-from pytorch_lightning.utilities.argparse import add_argparse_args
 from torch.utils.data import DataLoader, Dataset
 
 from vital.data.config import DataParameters, Subset
@@ -20,14 +19,14 @@ class VitalDataModule(pl.LightningDataModule, ABC):
         """Initializes class instance.
 
         References:
-            - ``workers`` documentation, for more detail:
-              https://pytorch-lightning.readthedocs.io/en/stable/benchmarking/performance.html#num-workers
+            - ``num_workers`` documentation, for more detail:
+              https://lightning.ai/docs/pytorch/stable/advanced/speed.html#num-workers
 
         Args:
             data_params: Parameters related to the data necessary to initialize networks working with this dataset.
             batch_size: Size of batches.
-            num_workers: Number of subprocesses to use for data loading.
-                ``workers=0`` means that the data will be loaded in the main process.
+            num_workers: Number of subprocesses to use for data loading. ``num_workers=0`` means that the data will be
+                loaded in the main process.
         """
         super().__init__()
         self.data_params = data_params
@@ -57,4 +56,13 @@ class VitalDataModule(pl.LightningDataModule, ABC):
 
     @classmethod
     def add_argparse_args(cls, parent_parser: ArgumentParser, **kwargs) -> ArgumentParser:  # noqa: D102
-        return add_argparse_args(cls, add_argparse_args(VitalDataModule, parent_parser))
+        parser = ArgumentParser(parents=[parent_parser], add_help=False)
+        parser.add_argument("--batch_size", type=int, required=True, help="Size of batches")
+        parser.add_argument(
+            "--num_workers",
+            type=int,
+            default=os.cpu_count() - 1,
+            help="Number of subprocesses to use for data loading. ``workers=0`` means that the data will be loaded in "
+            "the main process",
+        )
+        return parser

--- a/vital/runner.py
+++ b/vital/runner.py
@@ -12,7 +12,7 @@ import torch
 from dotenv import load_dotenv
 from omegaconf import DictConfig, open_dict
 from pytorch_lightning import Trainer, seed_everything
-from pytorch_lightning.loggers import CometLogger, LightningLoggerBase
+from pytorch_lightning.loggers import CometLogger, Logger
 
 from vital.data.data_module import VitalDataModule
 from vital.system import VitalSystem
@@ -87,12 +87,8 @@ class VitalRunner(ABC):
                 prediction_writer_kwargs["postprocessors"] = postprocessors
             callbacks.append(hydra.utils.instantiate(predict_node, **prediction_writer_kwargs))
 
-        if cfg.resume:
-            trainer = Trainer(resume_from_checkpoint=cfg.ckpt_path, logger=experiment_logger, callbacks=callbacks)
-        else:
-            trainer: Trainer = hydra.utils.instantiate(cfg.trainer, logger=experiment_logger, callbacks=callbacks)
-
-            trainer.logger.log_hyperparams(Namespace(**cfg))  # Save config to logger.
+        trainer: Trainer = hydra.utils.instantiate(cfg.trainer, logger=experiment_logger, callbacks=callbacks)
+        trainer.logger.log_hyperparams(Namespace(**cfg))  # Save config to logger.
 
         if isinstance(trainer.logger, CometLogger):
             experiment_logger.experiment.log_asset_folder(".hydra", log_file_name=True)
@@ -115,11 +111,11 @@ class VitalRunner(ABC):
                 logger.info(f"Loading model from {ckpt_path}")
                 model = model.load_from_checkpoint(ckpt_path, data_params=datamodule.data_params, strict=cfg.strict)
 
-        if cfg.tune:
-            trainer.tune(model, datamodule=datamodule)
-
         if cfg.train:
-            trainer.fit(model, datamodule=datamodule)
+            if cfg.resume:
+                trainer.fit(model, datamodule=datamodule, ckpt_path=cfg.ckpt_path)
+            else:
+                trainer.fit(model, datamodule=datamodule)
 
             if not cfg.trainer.get("fast_dev_run", False):
                 # Copy best model checkpoint to a predictable path + online tracker (if used)
@@ -167,7 +163,7 @@ class VitalRunner(ABC):
         return cfg
 
     @staticmethod
-    def configure_logger(cfg: DictConfig) -> Union[bool, LightningLoggerBase]:
+    def configure_logger(cfg: DictConfig) -> Union[bool, Logger]:
         """Initializes Lightning logger.
 
         Args:

--- a/vital/utils/saving.py
+++ b/vital/utils/saving.py
@@ -4,9 +4,9 @@ from pathlib import Path
 from typing import Type, Union
 
 import comet_ml
+import pytorch_lightning as pl
 import torch
 from packaging.version import InvalidVersion, Version
-from pytorch_lightning.core.saving import ModelIO
 from torch.types import Device
 
 from vital import get_vital_home
@@ -125,7 +125,7 @@ def load_from_checkpoint(
     ckpt_path = resolve_model_checkpoint_path(checkpoint)
 
     # Extract which class to load from the hyperparameters saved in the checkpoint
-    ckpt_hparams = torch.load(ckpt_path)[ModelIO.CHECKPOINT_HYPER_PARAMS_KEY]
+    ckpt_hparams = torch.load(ckpt_path)[pl.LightningModule.CHECKPOINT_HYPER_PARAMS_KEY]
     system_cls = import_from_module(ckpt_hparams["task"]["_target_"])
 
     # Restore the model from the checkpoint


### PR DESCRIPTION
Breaking changes in Lightning that were fixed:
- Removal of tune phase
- Removal of `add_argparse_args` method to automatically populate args from init parameters
- Removal of `ModelIO` mixin, replaced by direct call to `LightningModule`
- Update default value of `Trainer`'s `devices` flag  from `None` to `auto`
- Explicit `resume_from_checkpoint` method behavior to resume training state now achieved by simply passing `ckpt_path` to `fit` method