### PR TITLE
Add warning to LV volumes computation when (likely) multi-class masks are provided

### DIFF
--- a/vital/metrics/evaluate/clinical/heart_us.py
+++ b/vital/metrics/evaluate/clinical/heart_us.py
@@ -1,6 +1,7 @@
 # Disable flak8 entirely because this file was mostly copied over from external sources and
 # the quality of the codebase and documentation is not up to par with the project's standards
 # flake8: noqa
+import logging
 from numbers import Real
 from typing import Tuple
 
@@ -8,6 +9,8 @@ import numpy as np
 from skimage.measure import find_contours
 
 from vital.utils.image.transform import resize_image_to_isotropic
+
+logger = logging.getLogger(__name__)
 
 
 def compute_left_ventricle_volumes(
@@ -35,6 +38,15 @@ def compute_left_ventricle_volumes(
     Returns:
         Left ventricle ED and ES volumes.
     """
+    for mask_name, mask in [("a2c_ed", a2c_ed), ("a2c_es", a2c_es), ("a4c_ed", a4c_ed), ("a4c_es", a4c_es)]:
+        if mask.max() > 1:
+            logger.warning(
+                f"`compute_left_ventricle_volumes` expects binary segmentation masks of the left ventricle (LV). "
+                f"However, the `{mask_name}` segmentation contains a label greater than '1/True'. If this was done "
+                f"voluntarily, you can safely ignore this warning. However, the most likely cause is that you forgot "
+                f"to extract the binary LV segmentation from a multi-class segmentation mask."
+            )
+
     a2c_ed_diameters, a2c_ed_step_size = _compute_diameters(a2c_ed, a2c_voxelspacing)
     a2c_es_diameters, a2c_es_step_size = _compute_diameters(a2c_es, a2c_voxelspacing)
     a4c_ed_diameters, a4c_ed_step_size = _compute_diameters(a4c_ed, a4c_voxelspacing)


### PR DESCRIPTION
The `compute_left_ventricle_volumes` function expects binary masks of the left ventricle (LV), but won't error out on segmentation with arbitrary labels (instead treating any "truthy" value as part of the binary mask). This lead users on multiple occasions to provide multi-class segmentation masks (w/o the LV being extracted first), which lead to obviously wrong results but w/o any errors.

Therefore, this warning is being added to flag the user-error quicker in the future, w/o outright raising an error, in case some users are aware of the masking behavior and rely on it.