### PR TITLE
Add config option for `torchinfo.summary`'s `mode` parameter

### DIFF
--- a/vital/config/task/default.yaml
+++ b/vital/config/task/default.yaml
@@ -5,6 +5,7 @@ defaults:
 
 _target_: ???
 enable_model_summary: ${oc.select:trainer.enable_model_summary,True}
+model_summary_mode: eval
 
 train_log_kwargs:
   prog_bar: False

--- a/vital/system.py
+++ b/vital/system.py
@@ -127,6 +127,7 @@ class VitalSystem(pl.LightningModule, ABC):
                 col_names=["input_size", "output_size", "kernel_size", "num_params"],
                 depth=sys.maxsize,
                 device=self.device,
+                mode=self.hparams.model_summary_mode,
                 verbose=0,
             )
             (self.log_dir / "summary.txt").write_text(str(model_summary), encoding="utf-8")


### PR DESCRIPTION
In some cases, some layers (e.g. `TransformerEncoderLayer`) can use fast execution paths that bypass their submodule, failing to register the submodules for `torchinfo`.

In those cases, it can be necessary to use `train` mode to force the execution of the submodules so that they can be picked up by `torchinfo`.

c.f. [this `torchinfo` issue](https://github.com/TylerYep/torchinfo/issues/213) for more info.