### PR TITLE
Fix MTR implementation to respect the documented expected shape of MASK token

### DIFF
--- a/vital/data/augmentation/base.py
+++ b/vital/data/augmentation/base.py
@@ -13,7 +13,9 @@ def random_masking(x: Tensor, mask_token: Tensor, p: float) -> Tuple[Tensor, Ten
 
     Args:
         x: (N, S, E) Batch of sequences of tokens.
-        mask_token: (E) Mask to replace masked tokens with.
+        mask_token: (E) or (S, E) Mask to replace masked tokens with. If a single token of dimension (E), then the mask
+            will be used to replace any tokens in the sequence. Otherwise, each token in the sequence has to to have its
+            own MASK token to be replaced with.
         p: Probability to replace a token by the mask token.
 
     Returns:
@@ -31,6 +33,15 @@ def random_masking(x: Tensor, mask_token: Tensor, p: float) -> Tuple[Tensor, Ten
     broadcast_mask = mask.unsqueeze(-1).to(device=x.device, dtype=torch.float)
     broadcast_mask = broadcast_mask.repeat(1, 1, d)
 
-    mask_tokens = mask_token.repeat(n, s, 1)
+    if mask_token.ndim == 1:
+        mask_tokens = mask_token[None, None, ...].repeat(n, s, 1)
+    elif mask_token.ndim == 2:
+        mask_tokens = mask_token[None, ...].repeat(n, 1, 1)
+    else:
+        raise ValueError(
+            "The `mask_token` parameter passed to `random_masking` should be of dimensions (E) or (S, E), where E is "
+            "the embedding size and S is the sequence length."
+        )
+
     x_masked = x * (1 - broadcast_mask) + mask_tokens * broadcast_mask
     return x_masked, mask


### PR DESCRIPTION
Also used this opportunity to add support for providing one MASK token per attribute.