### PR TITLE
Update `Measure` and `EchoMeasure` to add new measures and standardize existing ones

### DIFF
--- a/vital/utils/image/measure.py
+++ b/vital/utils/image/measure.py
@@ -28,7 +28,8 @@ class Measure:
             voxelarea: Size of the mask's voxels along each (height, width) dimension (in mm).
 
         Returns:
-            ([N]), Number of pixels associated to the structure, in each segmentation of the batch.
+            ([N]), Surface associated to the structure (in mm² if `voxelspacing` and pixels otherwise), in each
+            segmentation of the batch.
         """
         if labels:
             mask = np.isin(segmentation, labels)

--- a/vital/utils/image/us/measure.py
+++ b/vital/utils/image/us/measure.py
@@ -375,8 +375,8 @@ class EchoMeasure(Measure):
             voxelspacing: Size of the segmentation's voxels along each (height, width) dimension (in mm).
 
         Returns:
-            ([N]), Number of pixels associated with the structure that falls on the left/right side of the endo center
-            line, in each segmentation of the batch.
+            ([N]), Surface associated with the structure (in mm² if `voxelspacing` and pixels otherwise) that falls on
+            the left/right side of the endo center line, in each segmentation of the batch.
         """
         # Find the binary mask of the structure
         if labels:
@@ -516,8 +516,7 @@ class EchoMeasure(Measure):
             voxelspacing: Size of the segmentation's voxels along each (height, width) dimension (in mm).
 
         Returns:
-            ([N]), Distance between the left and right markers at the base of the left ventricle, or NaNs for the
-            images where those 2 points cannot be reliably estimated.
+            ([N]), Distance between the left and right markers at the base of the left ventricle (in cm).
         """
         voxelspacing = np.array(voxelspacing)
 
@@ -525,7 +524,9 @@ class EchoMeasure(Measure):
         left_corner, right_corner = EchoMeasure._endo_base(segmentation, lv_labels, myo_labels)
 
         # Compute the distance between the points at the base
-        return np.linalg.norm((left_corner - right_corner) * voxelspacing)
+        width = np.linalg.norm((left_corner - right_corner) * voxelspacing)
+        width *= 1e-1  # Convert from mm to cm
+        return width
 
     @staticmethod
     @auto_cast_data
@@ -545,7 +546,7 @@ class EchoMeasure(Measure):
             voxelspacing: Size of the segmentation's voxels along each (height, width) dimension (in mm).
 
         Returns:
-            ([N]), Length of the left ventricle.
+            ([N]), Length of the left ventricle (in cm).
         """
         voxelspacing = np.array(voxelspacing)
 
@@ -557,7 +558,9 @@ class EchoMeasure(Measure):
         )[0]
 
         # Compute the distance between the apex and the base's midpoint
-        return np.linalg.norm((apex - base_mid) * voxelspacing)
+        length = np.linalg.norm((apex - base_mid) * voxelspacing)
+        length *= 1e-1  # Convert from mm to cm
+        return length
 
     @staticmethod
     @auto_cast_data

--- a/vital/utils/image/us/tests/curvature_test.py
+++ b/vital/utils/image/us/tests/curvature_test.py
@@ -1,0 +1,44 @@
+def main():
+    """Run the test script."""
+    import argparse
+    from math import ceil
+    from unittest.mock import patch
+
+    import numpy as np
+
+    from vital.utils.image.us.measure import EchoMeasure
+
+    parser = argparse.ArgumentParser(description="Compute the curvature of a circle of known radius.")
+    parser.add_argument("--radius", type=float, default=50, help="Radius of the circle")
+    parser.add_argument("--num_points", type=int, default=40, help="Number of points to sample along the circle")
+    parser.add_argument("--voxel_size", type=float, default=0.2, help="Voxel size (in mm)")
+    parser.add_argument("--debug_plot", action="store_true", help="Whether to plot the curvature")
+    args = parser.parse_args()
+
+    def sample_circle(radius: float, num_points: int, pixel_coords: bool = False) -> np.ndarray:
+        """Sample points along the circumference of a circle of known radius."""
+        theta = np.linspace(0, 2 * np.pi, num_points)
+        x = radius * np.cos(theta)
+        y = radius * np.sin(theta)
+        coords = np.vstack([y, x]).T
+        if pixel_coords:
+            # Convert from exact floating-point coordinates to integer coordinates
+            # + offset from origin so that the circle falls in the positive quadrant
+            coords = coords.astype(int) + ceil(radius)
+        return coords
+
+    circle_samples = sample_circle(args.radius, args.num_points, pixel_coords=args.debug_plot)
+    mask = np.zeros(np.ceil(circle_samples.max(axis=0)).astype(int) + 1)
+
+    # Mock the measure object to return a known set of control points that the domain-specific code could not extract
+    # from the circle
+    with patch.object(EchoMeasure, "control_points", return_value=circle_samples):
+        # Compute the curvature of the circle
+        curvature = EchoMeasure.curvature(
+            mask, None, None, None, num_control_points=60, voxelspacing=args.voxel_size, debug_plots=args.debug_plot
+        )
+        print(f"Computed curvature (in dm^-1): {curvature}")
+
+
+if __name__ == "__main__":
+    main()

--- a/vital/utils/image/us/tests/myo_thickness_test.py
+++ b/vital/utils/image/us/tests/myo_thickness_test.py
@@ -1,0 +1,64 @@
+def main():
+    """Run the test script."""
+    import argparse
+    from math import ceil
+    from unittest.mock import patch
+
+    import numpy as np
+    from skimage.morphology import disk
+
+    from vital.utils.image.us.measure import EchoMeasure
+
+    parser = argparse.ArgumentParser(
+        description="Compute the thickness of the band between an inner and an outer circle of known radii."
+    )
+    parser.add_argument("--in_radius", type=float, default=80, help="Radius of the inner circle")
+    parser.add_argument("--out_radius", type=float, default=100, help="Radius of the outer circle")
+    parser.add_argument(
+        "--num_points", type=int, default=40, help="Number of points to sample in the center of the band"
+    )
+    parser.add_argument("--voxel_size", type=float, default=0.5, help="Voxel size (in mm)")
+    parser.add_argument("--debug_plot", action="store_true", help="Whether to plot the curvature")
+    args = parser.parse_args()
+
+    radius_diff = args.out_radius - args.in_radius
+
+    def sample_circle(radius: float, num_points: int, pixel_coords: bool = False) -> np.ndarray:
+        """Sample points along the circumference of a circle of known radius."""
+        # Generate points in clockwise order, because that's what the function for computing the curvature expects
+        theta = np.linspace(0, 2 * np.pi, num_points)
+        x = radius * np.cos(theta)
+        y = radius * np.sin(theta)
+        coords = np.vstack([y, x]).T
+        if pixel_coords:
+            # Convert from exact floating-point coordinates to integer coordinates
+            # + offset from origin so that the circle falls between the inner and outer circles in the positive quadrant
+            # + additional offset of 1 to account for the padding of the mask
+            coords = coords.astype(int) + ceil(radius) + (radius_diff // 2) + 1
+        return coords
+
+    center_samples = sample_circle(
+        (args.out_radius + args.in_radius) // 2, args.num_points, pixel_coords=args.debug_plot
+    )
+    # Create masks of the inner/outer circles
+    # + pad the inner circle by the difference in radii so that its center matches the outer circle's
+    outer_mask = disk(args.out_radius)
+    inner_mask = np.pad(disk(args.in_radius), ((radius_diff, radius_diff), (radius_diff, radius_diff)), mode="constant")
+
+    # Combine the inner and outer and assign them the appropriate labels
+    mask = outer_mask * 2
+    mask[inner_mask.astype(bool)] = 1
+    mask = np.pad(mask, ((1, 1), (1, 1)), mode="constant")
+
+    # Mock the measure object to return a known set of control points that the domain-specific code could not extract
+    # from the circle
+    with patch.object(EchoMeasure, "control_points", return_value=center_samples):
+        # Compute the curvature of the circle
+        thickness = EchoMeasure.myo_thickness(
+            mask, 1, 2, num_control_points=60, voxelspacing=args.voxel_size, debug_plots=args.debug_plot
+        )
+        print(f"Computed thickness (in cm): {thickness}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Standardize the units of values returned (and/or the documentation of the return value) for previous methods: `surface_area`, `structure_area_split_by_endo_center_line`, `lv_base_width` and `lv_length`. The units were chosen as ones values in the literature are typically reported in;
- Add new `EchoMeasure` methods + test of the new measures on synthetic examples:
  - `myo_thickness`
  - `curvature`